### PR TITLE
Remove the timestamps in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,9 +46,6 @@ io.on('connection', function(client) {
 				responseToClient = responseWitAI;
 				}
 			}
-			var currentTime = new Date();
-			var currentHour = currentTime.getUTCHours();
-			var currentMin = currentTime.getUTCMinutes();
 			client.emit('thread', '<div class=\'chat bot\' ><div class=\'user-photo\'></div><p class=\'chat-message\' >' + responseToClient +'</p></div>');
 			return;
 		}).catch(console.error);


### PR DESCRIPTION
Currently no timestamps in the chats are needed.
For a better readability and because out
commented code is an antipattern, this unnecessary
code gets removed.